### PR TITLE
set java version to expect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,14 @@
     </testResources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Without it all kinds of errors occur when trying to run cobertura:

$ mvn cobertura:cobertura
...
[INFO] Compilation failure

/home/echrgys/projects/dojo/dojo.exercises/src/main/java/dojo/factory/Farmer.java:[4,34] variable-arity methods are not supported in -source 1.3
(use -source 5 or higher to enable variable-arity methods)
    public static void main(String... args) {

/home/echrgys/projects/dojo/dojo.exercises/src/main/java/dojo/dependency/Gamer.java:[9,34] variable-arity methods are not supported in -source 1.3
(use -source 5 or higher to enable variable-arity methods)
    public static void main(String... args) {

/home/echrgys/projects/dojo/dojo.exercises/src/main/java/dojo/dependency/Gamer.java:[19,32] for-each loops are not supported in -source 1.3
(use -source 5 or higher to enable for-each loops)
            for (String element : fizzBuzz.play(start, stop)) {
